### PR TITLE
Scripts are now POSIX-compliant. Fix install for BSD and Gentoo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-if type "clang" > /dev/null 2>&1 ; then
+if command   -v "clang" > /dev/null 2>&1 ; then
     CC=clang
-elif type "gcc" > /dev/null 2>&1 ; then
+elif command -v "gcc" > /dev/null 2>&1 ; then
     CC=gcc
+elif command -v "cc" > /dev/null 2>&1 ; then
+    CC=cc
 else
-    echo -e "\e[1;31mNo compiler found! Please install clang or gcc.\e[0m"
+    printf "\033[1;31mNo compiler found! Please install clang or gcc.\033[0m\n"
     exit 1
 fi
 
 $CC -O2 -std=c99 -I. -c -o printhex.o printhex.c || exit 1
 
 rm libprinthex.a > /dev/null 2>&1
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
 ar qs libprinthex.a printhex.o
 else
 ar qfs libprinthex.a printhex.o

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 PREFIX=/usr/local
-if [ "$(uname)" == "Darwin" ]; then
-install -m 644 -v libprinthex.a $PREFIX/lib
-install -m 644 -v printhex.h    $PREFIX/include
+mkdir -p $PREFIX/lib
+mkdir -p $PREFIX/include
+
+if [ "$(uname)" = "Darwin" ]; then
+install -m 644 -v libprinthex.a $PREFIX/lib/
+install -m 644 -v printhex.h    $PREFIX/include/
 else
-install -m 644 -v -g root -o root libprinthex.a $PREFIX/lib
-install -m 644 -v -g root -o root printhex.h    $PREFIX/include
+install -m 644 -v -o root libprinthex.a $PREFIX/lib/
+install -m 644 -v -o root printhex.h    $PREFIX/include/
 fi

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 clang -std=c99 -L. -I. -o phtest test.c -lprinthex && ./phtest
 


### PR DESCRIPTION
I make the scripts independent of bash, making them POSIX compatible.
The install script look for /usr/local/include, but in Gentoo, that directory does not exist, create the directories with `mkdir -p` solves the problem.
The build.sh looks only for clang and gcc compilers, adding the `cc` command alternative looks for default system compiler. 
I replaced the ANSI escape '\e' with \033 and replaced echo with printf command. now the script works on any shell.